### PR TITLE
Ignore comments in ibus config file 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore comments in IBus config file. This fixes things on Ubuntu 20.04.
+
 ## [2.0.1] - 2019-10-22
 
 ### Changed

--- a/ibusdotnet.sln.DotSettings
+++ b/ibusdotnet.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=IBUS/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/IBusConnectionFactory.cs
+++ b/src/IBusConnectionFactory.cs
@@ -108,7 +108,7 @@ namespace IBusDotNet
 				{
 					var line = streamReader.ReadLine();
 
-					if (!string.IsNullOrEmpty(line) && line.Contains(IBUS_ADDRESS))
+					if (!string.IsNullOrEmpty(line) && !line.StartsWith("#") && line.Contains(IBUS_ADDRESS))
 					{
 						var tokens = line.Split("=".ToCharArray(), 2);
 						if (tokens.Length != 2 || tokens[1] == string.Empty)


### PR DESCRIPTION
The ibus version included in Ubuntu 20.04 adds comments to the ibus config file, one of which includes the string IBUS_ADDRESS.
This change ingores comments in the config file, therefore fixing things on Ubuntu 20.04.