### PR TITLE
Remove dependency on SIL.ReleaseTasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.3] - 2020-08-28
+
+### Fixed
+
+- Remove dependency on `SIL.ReleaseTasks`
+
 ## [2.0.2] - 2020-08-28
 
 ### Fixed

--- a/ibusdotnetTests/IBusConnectionFactoryTests.cs
+++ b/ibusdotnetTests/IBusConnectionFactoryTests.cs
@@ -16,13 +16,13 @@ namespace IBusDotNet
 	{
 		private string m_OriginalDisplay;
 
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void FixtureSetup()
 		{
 			m_OriginalDisplay = Environment.GetEnvironmentVariable("DISPLAY");
 		}
 
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		public void FixtureTearDown()
 		{
 			Environment.SetEnvironmentVariable("DISPLAY", m_OriginalDisplay);
@@ -32,60 +32,54 @@ namespace IBusDotNet
 		public void GetDisplayNumber_NoEnv()
 		{
 			Environment.SetEnvironmentVariable("DISPLAY", null);
-			string hostname;
-			int displayNumber = IBusConnectionFactory.GetDisplayNumber(out hostname);
-			Assert.AreEqual(0, displayNumber);
-			Assert.AreEqual("unix", hostname);
+			var displayNumber = IBusConnectionFactory.GetDisplayNumber(out var hostname);
+			Assert.That(displayNumber, Is.EqualTo(0));
+			Assert.That(hostname, Is.EqualTo("unix"));
 		}
 
 		[Test]
 		public void GetDisplayNumber_DisplayOnly()
 		{
 			Environment.SetEnvironmentVariable("DISPLAY", ":5");
-			string hostname;
-			int displayNumber = IBusConnectionFactory.GetDisplayNumber(out hostname);
-			Assert.AreEqual(5, displayNumber);
-			Assert.AreEqual("unix", hostname);
+			var displayNumber = IBusConnectionFactory.GetDisplayNumber(out var hostname);
+			Assert.That(displayNumber, Is.EqualTo(5));
+			Assert.That(hostname, Is.EqualTo("unix"));
 		}
 
 		[Test]
 		public void GetDisplayNumber_DisplayWithScreen()
 		{
 			Environment.SetEnvironmentVariable("DISPLAY", ":6.7");
-			string hostname;
-			int displayNumber = IBusConnectionFactory.GetDisplayNumber(out hostname);
-			Assert.AreEqual(6, displayNumber);
-			Assert.AreEqual("unix", hostname);
+			var displayNumber = IBusConnectionFactory.GetDisplayNumber(out var hostname);
+			Assert.That(displayNumber, Is.EqualTo(6));
+			Assert.That(hostname, Is.EqualTo("unix"));
 		}
 
 		[Test]
 		public void GetDisplayNumber_DisplayWithHostname()
 		{
 			Environment.SetEnvironmentVariable("DISPLAY", "foo:8.0");
-			string hostname;
-			int displayNumber = IBusConnectionFactory.GetDisplayNumber(out hostname);
-			Assert.AreEqual(8, displayNumber);
-			Assert.AreEqual("foo", hostname);
+			var displayNumber = IBusConnectionFactory.GetDisplayNumber(out var hostname);
+			Assert.That(displayNumber, Is.EqualTo(8));
+			Assert.That(hostname, Is.EqualTo("foo"));
 		}
 
 		[Test]
 		public void GetDisplayNumber_DisplayWithHostnameWithPeriod()
 		{
 			Environment.SetEnvironmentVariable("DISPLAY", "foo.local:8.0");
-			string hostname;
-			int displayNumber = IBusConnectionFactory.GetDisplayNumber(out hostname);
-			Assert.AreEqual(8, displayNumber);
-			Assert.AreEqual("foo.local", hostname);
+			var displayNumber = IBusConnectionFactory.GetDisplayNumber(out var hostname);
+			Assert.That(displayNumber, Is.EqualTo(8));
+			Assert.That(hostname, Is.EqualTo("foo.local"));
 		}
 
 		[Test]
 		public void GetDisplayNumber_Invalid()
 		{
 			Environment.SetEnvironmentVariable("DISPLAY", "f.1");
-			string hostname;
-			int displayNumber = IBusConnectionFactory.GetDisplayNumber(out hostname);
-			Assert.AreEqual(0, displayNumber);
-			Assert.AreEqual("unix", hostname);
+			var displayNumber = IBusConnectionFactory.GetDisplayNumber(out var hostname);
+			Assert.That(displayNumber, Is.EqualTo(0));
+			Assert.That(hostname, Is.EqualTo("unix"));
 		}
 	}
 }

--- a/ibusdotnetTests/IBusDotNetTests.cs
+++ b/ibusdotnetTests/IBusDotNetTests.cs
@@ -22,8 +22,7 @@ namespace IBusDotNet
 		[TearDown]
 		public void TearDown()
 		{
-			if (Connection != null)
-				Connection.Dispose();
+			Connection?.Dispose();
 			Connection = null;
 		}
 

--- a/ibusdotnetTests/ibusdotnetTests.csproj
+++ b/ibusdotnetTests/ibusdotnetTests.csproj
@@ -1,60 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{976F7BF8-DDEC-4FF5-91D0-5D8F94FB7343}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>ibusdotnetTests</RootNamespace>
-    <AssemblyName>ibusdotnetTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <Configurations>Debug;Release</Configurations>
+    <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\ibusdotnet.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>../ibusdotnet.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>True</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>False</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>False</ConsolePause>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
-    <Optimize>False</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>False</ConsolePause>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="IBusConnectionFactoryTests.cs" />
-    <Compile Include="IBusDotNetTests.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <None Include="..\ibusdotnet.snk">
-      <Link>ibusdotnet.snk</Link>
-    </None>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\src\ibusdotnet.csproj">
-      <Project>{1292efa8-b018-4573-b46c-1549760b64f0}</Project>
-      <Name>ibusdotnet</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\src\ibusdotnet.csproj" />
   </ItemGroup>
 
-  <Target Name="Restore" />
-  <Target Name="Pack" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+  </ItemGroup>
+
 </Project>

--- a/ibusdotnetTests/packages.config
+++ b/ibusdotnetTests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net35" />
-</packages>

--- a/src/ibusdotnet.csproj
+++ b/src/ibusdotnet.csproj
@@ -23,11 +23,9 @@ See full changelog at https://github.com/sillsdev/ibusdotnet/blob/master/CHANGEL
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.6">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="GitVersionTask" Version="5.3.7" PrivateAssets="all" />
     <PackageReference Include="NDesk.DBus" Version="0.15.0" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.2" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.3" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- SIL.ReleaseTasks is a build dependency that should not end up in the nuget package.
- Update dependencies
- Switch unit tests to NUnit 3.12

