### PR TITLE
Connect when running in flatpak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Connect when running in Flatpak. App needs to set USER_CONFIG_HOME to host
+  XDG_CONFIG_HOME. Flatpak is detected from the presence of FLATPAK_ID.
+
 ## [2.0.3] - 2020-08-28
 
 ### Fixed

--- a/ibusdotnetTests/IBusConnectionFactoryTests.cs
+++ b/ibusdotnetTests/IBusConnectionFactoryTests.cs
@@ -38,6 +38,18 @@ namespace IBusDotNet
 		}
 
 		[Test]
+		public void GetDisplayNumber_Flatpak()
+		{
+			string displayInFlatpak = ":99.0";
+			Environment.SetEnvironmentVariable("DISPLAY", displayInFlatpak);
+			Environment.SetEnvironmentVariable("FLATPAK_ID", "org.foo.ClientApp");
+			var displayNumber = IBusConnectionFactory.GetDisplayNumber(out var hostname);
+			int assumedDisplayWhenFlatpak = 0;
+			Assert.That(displayNumber, Is.EqualTo(assumedDisplayWhenFlatpak));
+			Assert.That(hostname, Is.EqualTo("unix"));
+		}
+
+		[Test]
 		public void GetDisplayNumber_DisplayOnly()
 		{
 			Environment.SetEnvironmentVariable("DISPLAY", ":5");


### PR DESCRIPTION
- Change to /etc/machine-id. This works too, and is available in
flatpak.
- Allow client applications to specify USER_CONFIG_HOME to help
ibusdotnet know to look in a different place than XDG_CONFIG_HOME, so
the user config dir outside of the flatpak (eg ${HOME}/.config) can be
found. For example,
    `USER_CONFIG_HOME="${HOME}/.config" mono ClientApp.exe`
- Assume DISPLAY=:0 if flatpak.