### PR TITLE
move to nunit3, enhance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Attaches to a program listening for a debugger, such as from running:
+      // mono --debug --debugger-agent="address=localhost:55555,transport=dt_socket,server=y,suspend=n" App.exe
+      "name": "Attach",
+      "type": "mono",
+      "request": "attach",
+      "address": "localhost",
+      "port": 55555
+    },
+    {
+      "name": "Launch ibusTextBoxTest",
+      "env": {
+        // Use this mono.
+        // "PATH": "/opt/mono5-sil/bin:${env:PATH}",
+      },
+      "type": "mono",
+      "request": "launch",
+      "program": "${workspaceRoot}/ibusTextBoxTest/bin/Debug/ibusTextBox.exe",
+      "cwd": "${workspaceRoot}",
+    },
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,20 @@ Get the [ibusdotnet](https://www.nuget.org/packages/ibusdotnet/) nuget package.
 
 ## Building from source
 
-The project can be build with the following command:
+The project can be built with the following command:
 
 ```bash
-msbuild /t:Build build/ibusdotnet.proj
+msbuild build/ibusdotnet.proj -t:Build
+```
+
+Run tests:
+
+```bash
+msbuild build/ibusdotnet.proj -t:Test
+```
+
+Compile test app:
+
+```bash
+msbuild ibusTextBoxTest
 ```

--- a/build/ibusdotnet.proj
+++ b/build/ibusdotnet.proj
@@ -7,7 +7,7 @@
 		<Configuration Condition="'$(Configuration)'==''">Release</Configuration>
 		<useNUnit-x86 Condition="'$(OS)'=='Windows_NT'">true</useNUnit-x86>
 		<useNUnit-x86 Condition="'$(OS)'!='Windows_NT'">false</useNUnit-x86>
-		<OutputTestsDir>$(RootDir)/ibusdotnetTests/bin/$(Configuration)</OutputTestsDir>
+		<OutputTestsDir>$(RootDir)/output/$(Configuration)/net461</OutputTestsDir>
 		<OutputDir>$(RootDir)/output</OutputDir>
 		<excludedCategories>ICU50 Deprecated;ByHand;</excludedCategories>
 		<excludedCategories Condition="'$(IsOnWindows)'!='true'">$(excludedCategories)KnownMonoIssue;</excludedCategories>
@@ -19,11 +19,13 @@
 
 		<RestartBuild Condition="!Exists('$(MSBuildProjectDirectory)/packages/SIL.BuildTasks/tools/SIL.BuildTasks.dll')">true</RestartBuild>
 		<RestartBuild Condition="Exists('$(MSBuildProjectDirectory)/packages/SIL.BuildTasks/tools/SIL.BuildTasks.dll')">false</RestartBuild>
+		<TeamCity Condition="'$(teamcity_version)' != ''">true</TeamCity>
+		<TeamCity Condition="'$(teamcity_version)' == ''">false</TeamCity>
 	</PropertyGroup>
 
-	<UsingTask TaskName="SIL.BuildTasks.UnitTestTasks.NUnit3"
-		AssemblyFile="$(MSBuildProjectDirectory)/packages/SIL.BuildTasks/tools/SIL.BuildTasks.dll"
-		Condition="Exists('$(MSBuildProjectDirectory)/packages/SIL.BuildTasks/tools/SIL.BuildTasks.dll')" />
+	<UsingTask TaskName="NUnit3"
+		AssemblyFile="$(RootDir)/packages/SIL.BuildTasks/tools/SIL.BuildTasks.dll"
+		Condition="Exists('$(RootDir)/packages/SIL.BuildTasks/tools/SIL.BuildTasks.dll')" />
 	<UsingTask TaskName="NUnitTeamCity"
 		AssemblyFile="$(teamcity_dotnet_nunitlauncher_msbuild_task)"
 		Condition=" '$(teamcity_version)' != '' And '$(OS)'=='Windows_NT'"/>
@@ -36,7 +38,9 @@
 	<Target Name="RestoreBuildTasks" DependsOnTargets="CheckPrerequisites">
 		<Message Text="RestartBuild=$(RestartBuild)"/>
 		<Message Text="MSBuildProjectDirectory=$(MSBuildProjectDirectory)"/>
-		<Exec Command='$(NuGetCommand) install SIL.BuildTasks -excludeVersion -version 2.1.0 -source "$(PackageSources)" -solutionDirectory "$(MSBuildProjectDirectory)/."' />
+		<Exec Command='$(NuGetCommand) install SIL.BuildTasks -excludeVersion -version 2.3.1 -solutionDirectory "$(RootDir)"' />
+		<!-- Install NUnit.Console which has the required extensions as dependencies -->
+		<Exec Command='$(NuGetCommand) install NUnit.Console -excludeVersion -version 3.11.1 -solutionDirectory "$(RootDir)"' />
 	</Target>
 
 	<Target Name="Build">
@@ -90,15 +94,16 @@
 		<ItemGroup>
 			<TestAssemblies Include="$(OutputTestsDir)/*Tests.dll"/>
 		</ItemGroup>
-
-		<NUnit Assemblies="@(TestAssemblies)"
-			ToolPath="$(SolutionDir)/packages/NUnit.Runners.2.6.4/tools"
-			TestInNewThread="false"
-			ExcludeCategory="$(excludedCategories)$(ExtraExcludeCategories)"
+		<NUnit3
+			Assemblies="@(TestAssemblies)"
+			ToolPath="$(RootDir)/packages/NUnit.ConsoleRunner/tools"
+			ExcludeCategory="$(ExtraExcludeCategories)$(excludedCategories)"
 			WorkingDirectory="$(OutputTestsDir)"
 			Force32Bit="$(useNUnit-x86)"
 			Verbose="true"
-			OutputXmlFile="$(OutputTestsDir)/TestResults.xml"/>
+			UseNUnit3Xml="false"
+			OutputXmlFile="$(OutputTestsDir)/TestResults.xml"
+			TeamCity="$(TeamCity)"/>
 	</Target>
 
 	<Target Name="Restore">

--- a/ibusTextBoxTest/IBusTextBox.cs
+++ b/ibusTextBoxTest/IBusTextBox.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Windows.Forms;
 using IBusDotNet;
 
@@ -61,6 +62,14 @@ namespace Test
 				inputContext.HidePreeditText += HidePreeditTextEventHandler;
 				inputContext.ForwardKeyEvent += ForwardKeyEventHandler;
 				inputContext.DeleteSurroundingText += DeleteSurroundingText;
+
+				Console.WriteLine($"Input context engine: {inputContext.GetEngine()} Name: {inputContext.GetEngine().Name}");
+				Console.WriteLine($"IBus address: {ibus.GetAddress()}");
+				Console.WriteLine($"IBus current input context: {ibus.CurrentInputContext()}");
+				string engines = string.Join(", ", ibus.ListEngines().Select(e => e.Name));
+				string activeEngines = string.Join(", ", ibus.ListActiveEngines().Select(e => e.Name));
+				Console.WriteLine($"IBus engines: {ibus.ListEngines().Length}\n{engines}");
+				Console.WriteLine($"IBus active engines: {ibus.ListActiveEngines().Length}\n{activeEngines}");
 			}
 			else
 			{
@@ -77,6 +86,9 @@ namespace Test
 				inputContext.FocusIn();
 			}
 			base.OnGotFocus(e);
+
+			inputContext.SetEngine("table:thai");
+			Console.WriteLine($"Switched to input context engine: {inputContext.GetEngine()} Name: {inputContext.GetEngine().Name}");
 		}
 
 		protected override void OnLostFocus(EventArgs e)


### PR DESCRIPTION
====
These were not needed in getting keyboarding to work in flatpak, so I did not include them in the other PR. 
This PR gets the tests to run and adds more information to the ibusTextboxTest.
I also didn't realize that appveyor was already being used for pre-merge checking and so wrote a GHA pre-merge checker. I guess I can delete the GHA job being introduced in this PR unless there is a desire to use GHA for pre-merge checking. ?

I see that the GHA job for Linux fails, but it's about GitVersionTask. I've found that that can be fixed by deleting the PackageReference for GitVersionTask from src/ibusdotnet.csproj (but have not included that in the PR).
